### PR TITLE
Enable use of the libv8 gem

### DIFF
--- a/ext/mini_racer_extension/extconf.rb
+++ b/ext/mini_racer_extension/extconf.rb
@@ -1,4 +1,5 @@
 require 'mkmf'
+require 'libv8'
 
 have_library('pthread')
 have_library('objc') if RUBY_PLATFORM =~ /darwin/
@@ -19,40 +20,6 @@ if enable_config('debug')
   CONFIG['debugflags'] << ' -ggdb3 -O0'
 end
 
-LIBV8_COMPATIBILITY = '~> 5.0.71.35.0'
-
-# begin
-#   require 'rubygems'
-#   gem 'libv8', LIBV8_COMPATIBILITY
-# rescue Gem::LoadError
-#   warn "Warning! Unable to load libv8 #{LIBV8_COMPATIBILITY}."
-# rescue LoadError
-#   warn "Warning! Could not load rubygems. Please make sure you have libv8 #{LIBV8_COMPATIBILITY} installed."
-# ensure
-#   require 'libv8'
-# end
-#
-# Libv8.configure_makefile
-
-NODE_PATH = "/home/sam/Source/libv8"
-#NODE_PATH = "/Users/sam/Source/libv8"
-#
-NODE_LIBS = NODE_PATH + "/vendor/v8/out/x64.release"
-NODE_INCLUDE = NODE_PATH + "/vendor/v8/include"
-
-$INCFLAGS.insert 0, "-I#{NODE_INCLUDE} -I#{NODE_PATH}/vendor/v8 "
-$LDFLAGS.insert 0, " #{NODE_LIBS}/libv8_base.a #{NODE_LIBS}/libv8_libbase.a #{NODE_LIBS}/libv8_snapshot.a #{NODE_LIBS}/libv8_libplatform.a "
-
-# new change to mavrick means we need to link with libstdc++ instead of libc++ (the new default)
-$LDFLAGS.insert 0, " -stdlib=libstdc++ " if RUBY_PLATFORM =~ /darwin/
-
-dir_config('v8')
-find_header('v8.h')
-have_library('v8')
-
-# Temp Hack
-#find_header('v8.h', '/home/sam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/libv8-5.0.71.35.0/vendor/v8/include')
-
-#find_header('libplatform/libplatform.h', '/home/sam/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/libv8-5.0.71.35.0/vendor/v8/include')
+Libv8.configure_makefile
 
 create_makefile 'mini_racer_extension'

--- a/ext/mini_racer_extension/mini_racer_extension.cc
+++ b/ext/mini_racer_extension/mini_racer_extension.cc
@@ -1,8 +1,8 @@
 #include <stdio.h>
 #include <ruby.h>
 #include <ruby/thread.h>
-#include <v8.h>
-#include <libplatform/libplatform.h>
+#include <include/v8.h>
+#include <include/libplatform/libplatform.h>
 #include <ruby/encoding.h>
 #include <pthread.h>
 

--- a/mini_racer.gemspec
+++ b/mini_racer.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake-compiler"
 
-  #spec.add_dependency 'libv8', '~> 5.0.71.0'
+  spec.add_dependency 'libv8', '~> 5.0'
   spec.require_paths = ["lib", "ext"]
 
   spec.extensions = ["ext/mini_racer_extension/extconf.rb"]


### PR DESCRIPTION
libv8 5.0.71.48.1beta2 is up for testing, got mini_racer to compile and run tests with the changes below.